### PR TITLE
fix: added `disabled` and `hidden` types to `mapDays` return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -215,7 +215,7 @@ declare module "react-multi-date-picker" {
       selectedDate: DateObject | DateObject[];
       currentMonth: object;
       isSameDate(arg1: DateObject, arg2: DateObject): boolean;
-    }): HTMLAttributes<HTMLSpanElement> | void;
+    }): HTMLAttributes<HTMLSpanElement> & {disabled?: boolean, hidden?: boolean} | void;
     disableMonthPicker?: boolean;
     disableYearPicker?: boolean;
     /**


### PR DESCRIPTION
`mapDays` accepts `hidden` and `disabled` fields in its return, however, the types don't reflect this.

Closes #75 

