### PR TITLE
Added props to set the minute add/subtract interval in the TimePicker

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -680,6 +680,7 @@ declare module "react-multi-date-picker/plugins/time_picker" {
      */
     format?: string;
     header?: boolean;
+    intervalMinutesType?: "quarter" | "half";
   }
 
   export default function TimePicker(

--- a/src/plugins/time_picker/time_picker.js
+++ b/src/plugins/time_picker/time_picker.js
@@ -19,6 +19,7 @@ export default function TimePicker({
   handleFocusedDate,
   format = "YYYY/MM/DD",
   header = true,
+  intervalMinutesType,
   ...props
 }) {
   let { date, selectedDate, multiple, range, focused } = state,
@@ -97,6 +98,7 @@ export default function TimePicker({
               hideDivider={
                 name === "second" || (name === "minute" && hideSeconds)
               }
+              getIntervalMinutes={getIntervalMinutes}
             />
           );
         })}
@@ -116,9 +118,23 @@ export default function TimePicker({
   );
 
   function update(key, value) {
+    if (key === "minute") value = exceededIfMinutesZeroToConverting(value)
+
     availbleDate[key] = value;
 
     setDate();
+  }
+
+  function exceededIfMinutesZeroToConverting(minutes) {
+    if (availbleDate.minute % getIntervalMinutes() !== 0 && minutes > 60) return 60;
+    if (availbleDate.minute % getIntervalMinutes() !== 0 && minutes < 0) return 0;
+    return minutes;
+  }
+
+  function getIntervalMinutes() {
+    if (intervalMinutesType === "quarter") return 15;
+    if (intervalMinutesType === "half") return 30;
+    return 1;
   }
 
   function toggleMeridiem() {
@@ -149,11 +165,13 @@ function Button({
   update,
   digits,
   hideDivider,
+  getIntervalMinutes
 }) {
+  const intervalValue = name === "minute" ? getIntervalMinutes() : 1
   return (
     <>
       <div>
-        <Arrow direction="rmdp-up" onClick={() => update(name, number + 1)} />
+        <Arrow direction="rmdp-up" onClick={() => update(name, number + intervalValue)} />
         <Input
           max={max}
           value={localeValue}
@@ -161,7 +179,7 @@ function Button({
           digits={digits}
           name={name}
         />
-        <Arrow direction="rmdp-down" onClick={() => update(name, number - 1)} />
+        <Arrow direction="rmdp-down" onClick={() => update(name, number - intervalValue)} />
       </div>
       {!hideDivider && <span className="dvdr">:</span>}
     </>


### PR DESCRIPTION
#201

## background

I am trying to build an appointment planning application.

With an appointment planning app, I felt it would be easier to handle if the time could be advanced in 15/30 minute increments like Google Calendar.

I created an Issue because there was currently no such functionality, but since this was my first time participating in OSS, I implemented it myself as a learning experience.

## Summary
- Added props to set the minute add/subtract interval in the TimePicker
    -  15 minutes for "quarter", 30 minutes for "half", and 1 minute for all others.
    - The 15- or 30-minute intervals would always stop at 0 minutes, because the interval between 0 and 60 minutes could be exceeded.
    - Only minutes are supported, so hours and seconds are not affected.

## Movies
- https://drive.google.com/drive/folders/1VsE1G2UmiFm-qetmHNMuEm6hkAZHHcp4?usp=drive_link
    - Here is a video of it in motion. To avoid getting caught in the repository's capacity limit, we will share it on Google Drive.

---

Since this is a proposal-based implementation, we are not writing any specific documentation.

If this implementation is adopted, I will add a note to this page.

Thanks for the nice library.