### PR TITLE
make main calendar as well as date panel plugin keyboard accessible

### DIFF
--- a/src/components/arrow/arrow.js
+++ b/src/components/arrow/arrow.js
@@ -2,13 +2,14 @@ import React from "react";
 
 export default function Arrow({ direction, onClick, disabled }) {
   return (
-    <span
+    <button
       className={`rmdp-arrow-container ${direction} ${
         disabled ? "disabled" : ""
       }`}
       onClick={onClick}
+      aria-roledescription={`button to navigate ${direction}`}
     >
       <i className="rmdp-arrow"></i>
-    </span>
+    </button>
   );
 }

--- a/src/components/calendar/calendar.css
+++ b/src/components/calendar/calendar.css
@@ -1,9 +1,9 @@
 :root {
-  --rmdp-primary: #ffc132;
+  --rmdp-primary: #0074d9;
   --rmdp-secondary: #4ca6f5;
   --rmdp-shadow: #8798ad;
   --rmdp-today: #7fdbff;
-  --rmdp-hover: #E4913F;
+  --rmdp-hover: #7ea6f0;
   --rmdp-border: #cfd8e2;
   --highlight-red-color: #cc0303;
   --highlight-red-color-deactive: #e08e8e;
@@ -71,7 +71,7 @@
   cursor: pointer;
   position: relative;
   color: black;
-    background: transparent;
+  background: transparent;
   border: none;
   border-radius: 50%;
 }
@@ -438,6 +438,4 @@
   .rmdp-full-year {
     grid-template-columns: 1fr 1fr;
   }
-
-
 }

--- a/src/components/calendar/calendar.css
+++ b/src/components/calendar/calendar.css
@@ -1,9 +1,9 @@
 :root {
-  --rmdp-primary: #0074d9;
+  --rmdp-primary: #ffc132;
   --rmdp-secondary: #4ca6f5;
   --rmdp-shadow: #8798ad;
   --rmdp-today: #7fdbff;
-  --rmdp-hover: #7ea6f0;
+  --rmdp-hover: #E4913F;
   --rmdp-border: #cfd8e2;
   --highlight-red-color: #cc0303;
   --highlight-red-color-deactive: #e08e8e;
@@ -71,6 +71,9 @@
   cursor: pointer;
   position: relative;
   color: black;
+    background: transparent;
+  border: none;
+  border-radius: 50%;
 }
 
 .rmdp-week-day {
@@ -247,6 +250,8 @@
   display: flex;
   justify-content: center;
   margin: 0 5px;
+  background: transparent;
+  border: none;
 }
 
 .rmdp-arrow-container:hover {
@@ -433,4 +438,6 @@
   .rmdp-full-year {
     grid-template-columns: 1fr 1fr;
   }
+
+
 }

--- a/src/components/day_picker/day_picker.js
+++ b/src/components/day_picker/day_picker.js
@@ -121,28 +121,37 @@ export default function DayPicker({
 
                   let parentClassName = getClassName(object, numberOfMonths);
 
-                  if (object.hidden || object.disabled)
+                  if (object.hidden || object.disabled) {
                     className = className.replace("sd", "");
+                  }
 
                   return (
-                    <div
-                      key={i}
-                      className={parentClassName}
-                      onMouseEnter={() =>
-                        rangeHover && setDateHovered(object.date)
-                      }
-                      onClick={() => {
-                        if (!mustDisplayDay(object) || object.disabled) return;
+                    <>
+                      {!parentClassName.includes("hidden") ? (
+                        <button
+                          key={i}
+                          className={parentClassName}
+                          onMouseEnter={() =>
+                            rangeHover && setDateHovered(object.date)
+                          }
+                          onClick={(e) => {
+                            e.preventDefault();
+                            if (!mustDisplayDay(object) || object.disabled)
+                              return;
 
-                        selectDay(object, monthIndex, numberOfMonths);
-                      }}
-                    >
-                      <span className={className} {...allProps}>
-                        {mustDisplayDay(object) && !object.hidden
-                          ? children ?? object.day
-                          : ""}
-                      </span>
-                    </div>
+                            selectDay(object, monthIndex, numberOfMonths);
+                          }}
+                        >
+                          <span className={className} {...allProps}>
+                            {mustDisplayDay(object) && !object.hidden
+                              ? children ?? object.day
+                              : ""}
+                          </span>
+                        </button>
+                      ) : (
+                        <span key={i} className={parentClassName}></span>
+                      )}
+                    </>
                   );
                 })}
               </div>

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -166,7 +166,9 @@ export default function Header({
   function getButton(direction) {
     let handleClick = (e) => {
         e.preventDefault();
-        increaseValue(direction === "right" ? 1 : -1);
+        if(document.activeElement.classList.contains('rmdp-arrow-container')) {
+          increaseValue(direction === "right" ? 1 : -1);
+        }
       },
       disabled =
         (direction === "left" && isPreviousDisable) ||

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -111,6 +111,8 @@ export default function Header({
             </div>
           ));
         }
+      default:
+        return;
     }
   }
 
@@ -162,7 +164,10 @@ export default function Header({
   }
 
   function getButton(direction) {
-    let handleClick = () => increaseValue(direction === "right" ? 1 : -1),
+    let handleClick = (e) => {
+        e.preventDefault();
+        increaseValue(direction === "right" ? 1 : -1);
+      },
       disabled =
         (direction === "left" && isPreviousDisable) ||
         (direction === "right" && isNextDisable);

--- a/src/plugins/date_panel/date_panel.css
+++ b/src/plugins/date_panel/date_panel.css
@@ -1,5 +1,5 @@
 :root {
-  --rmdp-primary: #0074d9;
+  --rmdp-primary: #ffc132;
   --rmdp-shadow: #8798ad;
   --highlight-red-selected: #ea0034;
   --highlight-green-selected: #009688;
@@ -74,6 +74,13 @@
   transform: translateY(-50%) rotate(45deg);
   padding: 0;
   line-height: 5px;
+  background: transparent;
+}
+
+.rmdp-panel-body li .b-date {
+  border: none;
+  background-color: var(--rmdp-primary);
+  font-size: 14px;
 }
 
 .rmdp-panel-body li .b-deselect:focus {

--- a/src/plugins/date_panel/date_panel.css
+++ b/src/plugins/date_panel/date_panel.css
@@ -1,5 +1,5 @@
 :root {
-  --rmdp-primary: #ffc132;
+  --rmdp-primary: #0074d9;
   --rmdp-shadow: #8798ad;
   --highlight-red-selected: #ea0034;
   --highlight-green-selected: #009688;

--- a/src/plugins/date_panel/date_panel.js
+++ b/src/plugins/date_panel/date_panel.js
@@ -1,5 +1,4 @@
 import React from "react";
-import DateObject from "react-date-object";
 import getAllDatesInRange from "../../shared/getAllDatesInRange";
 import isArray from "../../shared/isArray";
 import getBorderClass from "../../shared/getBorderClass";
@@ -130,19 +129,28 @@ export default function DatePanel({
                   }`}
                 >
                   {[object].flat().map((object, index) => (
-                    <span
+                    <button
                       key={index}
-                      onClick={() => selectDate(object.date, object.index)}
+                      className="b-date"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        deSelect(date.index);
+                      }}
                       style={{ cursor: object.date ? "pointer" : "default" }}
+                      ariaDescription={`Date ${object.format} is selected. Click to unselect it.`}
                     >
                       {formatFunction ? formatFunction(object) : object.format}
-                    </span>
+                    </button>
                   ))}
                   {date && removeButton && (
                     <button
                       type="button"
                       className="b-deselect"
-                      onClick={() => deSelect(date.index)}
+                      tabIndex={-1}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        deSelect(date.index);
+                      }}
                     >
                       +
                     </button>
@@ -154,20 +162,6 @@ export default function DatePanel({
       </div>
     </div>
   );
-
-  function selectDate(date, index) {
-    handleClick(date ? selectedDate[index] : undefined);
-
-    if (!date) return;
-
-    setState({
-      ...state,
-      date: new DateObject(date),
-      focused: multiple && range ? date : selectedDate[index],
-    });
-
-    handleFocusedDate(selectedDate[index]);
-  }
 
   function deSelect(index) {
     let dates, focused;


### PR DESCRIPTION
Hello!
I have been using this repo as part of my project, Noodle (https://noodleapp.cool), but wanted to make the calendar keyboard accessible/navigable.
This is my first attempt at doing so, for at least the parts of this tool that my app uses. :) Further work on other plugins may come later, or be left as an exercise to the reader. ;)

NOTE: I was unable to test this locally, exclusive of Noodle, following the instructions in the `/website/readme.md`. Gatsby claims to require node 18+, but I get a bug when [starting Gatsby](https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported) that seems to imply that I need to downgrade to 16.0.

If you would like to see the changes in action on a live page, visit https://noodleapp.cool. Otherwise, I trust that the maintainer of the repo is able to pull this branch and test it in any way they see fit :)

Other notes:
-added a default case in the header to stop ESLint from yelling at me every time I compiled
-the selectDate function in DatePanel.js did not appear to be used but perhaps it is used for functionality that Noodle does not make use of. Please let me know.

Thank you for considering the PR.