### PR TITLE
fix: :bug: adding persist

### DIFF
--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -246,6 +246,7 @@ export default function Header({
   }
 
   function setTabIndex(e) {
+    e.persist();
     setTimeout(() => {
       const calendar = e.target.closest(".rmdp-calendar");
 


### PR DESCRIPTION
Error: 

`This synthetic event is reused for performance reasons. If you're seeing this, you're accessing the property "target" on a released/nullified synthetic event. This is set to null.`

Solution:

Added e.persist()