### PR TITLE
Use type-only import for Calendar to resolve naming conflict

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare module "react-multi-date-picker" {
   import React, { HTMLAttributes } from "react";
-  import DateObject, { Calendar, Locale } from "react-date-object";
+  import DateObject, { type Calendar, Locale } from "react-date-object";
 
   export type Value = Date | string | number | DateObject | null;
   export type FunctionalPlugin = { type: string; fn: Function };


### PR DESCRIPTION
## Type Import Conflict in index.d.ts

### Problem
When using `react-multi-date-picker` with TypeScript and the `isolatedModules` compiler option enabled in `tsconfig.json`, the following error occurs during build:
```
node_modules/react-multi-date-picker/index.d.ts:3:24 - error TS2865: Import 'Calendar' conflicts with local value, so must be declared with a type-only import when 'isolatedModules' is enabled.

3   import DateObject, { Calendar, Locale } from "react-date-object";
                         ~~~~~~~~


Found 1 error in node_modules/react-multi-date-picker/index.d.ts:3
```
This error suggests a naming conflict between the imported `Calendar` type and a local value with the same name.

### Proposed Solution
To resolve this issue, we can modify the import statement in `index.d.ts` to use a type-only import for `Calendar`. This change ensures that only the type information is imported, avoiding conflicts with any local values.

### Changes
In the file `node_modules/react-multi-date-picker/index.d.ts`, change:

```typescript
import DateObject, { Calendar, Locale } from "react-date-object";
```
to 

```typescript
import DateObject, { type Calendar, Locale } from "react-date-object";
```