### PR TITLE
fix: correct formatYear function judgement

### DIFF
--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -269,6 +269,6 @@ export default function Header({
   }
 
   function getYear(year, month) {
-    return typeof formatMonth === "function" ? formatYear(year, month) : year;
+    return typeof formatYear === "function" ? formatYear(year, month) : year;
   }
 }


### PR DESCRIPTION
The getYear function should judge whether the formatYear is a function